### PR TITLE
Fix for non-english instance of firefox

### DIFF
--- a/test/functional/GebConfig.groovy
+++ b/test/functional/GebConfig.groovy
@@ -7,7 +7,11 @@
 import org.openqa.selenium.firefox.FirefoxDriver
 
 driver = { 
-	def driverInstance = new FirefoxDriver() 
+    	//set the firefox locale to 'en-us' since the tests expect english
+    	//see http://stackoverflow.com/questions/9822717 for more details
+    	FirefoxProfile profile = new FirefoxProfile()
+    	profile.setPreference("intl.accept_languages", "en-us")
+	def driverInstance = new FirefoxDriver(profile) 
 	driverInstance.manage().window().maximize() 
 	driverInstance
 }


### PR DESCRIPTION
When you run the tests with a non-english instance of firefox, all tests will fail because the tests expect the english wording on the pages under test.
This change switches the used firefox instance to en_us and all tests will run fine :-)